### PR TITLE
[net-misc/cjdns] Correct epatch Name

### DIFF
--- a/net-misc/cjdns/cjdns-20-r1.ebuild
+++ b/net-misc/cjdns/cjdns-20-r1.ebuild
@@ -35,7 +35,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	epatch "${FILESDIR}/${P}-fix_systemd_units.patch"
+	epatch "${FILESDIR}/${PN}-fix_systemd_units.patch"
 }
 
 src_compile() {


### PR DESCRIPTION
This corrects an issue where the ebuild would look for and fail to find the patch that fixes the SystemD units.