### PR TITLE
Fixed CJDNS ebuild to use upstream runscript

### DIFF
--- a/net-misc/cjdns/cjdns-20.2.ebuild
+++ b/net-misc/cjdns/cjdns-20.2.ebuild
@@ -45,7 +45,7 @@ src_compile() {
 src_install() {
 	systemd_dounit contrib/systemd/cjdns.service
 	systemd_dounit contrib/systemd/cjdns-resume.service
-	newinitd "${FILESDIR}/cjdns.runscript" cjdns
+	newinitd contrib/openrc/cjdns cjdns
 
 	dodoc README.md
 	dosbin cjdroute


### PR DESCRIPTION
The included script uses the deprecated `/sbin/runscript` instead of `/sbin/openrc-run` which causes hangs at boot